### PR TITLE
Add dist Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,12 @@ install: dwmblocks
 	chmod 755 $(DESTDIR)$(PREFIX)/bin/dwmblocks
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/dwmblocks
+dist: clean
+	mkdir -p dwmblocks
+	cp -R LICENSE Makefile README.md preview.png\
+		config.h main.c dwmblocks
+	tar -cf dwmblocks.tar dwmblocks
+	gzip dwmblocks.tar
+	rm -rf dwmblocks
 
 .PHONY: clean install uninstall


### PR DESCRIPTION
This creates a target similar to that found in dwm's Makefile. I use this to make packaging consistent.
Of course this doesn't preserve a version number, git or otherwise, in the archive.