### PR TITLE
improve Makefile and config.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LDLIBS = -lX11
 
 BIN = dwmblocks
 
-$(BIN): main.o
+$(BIN): main.o config.h
 	$(CC) $^ -o $@ $(LDLIBS)
 
 clean:

--- a/config.h
+++ b/config.h
@@ -2,6 +2,15 @@
 #define DELIMITER "  "
 #define CLICKABLE_BLOCKS
 
+#define BLOCK(cmd, interval, signal) \
+    { "echo \"$(" cmd ")\"", interval, signal }
+
+typedef const struct {
+    const char *command;
+    const unsigned int interval;
+    const unsigned int signal;
+} Block;
+
 const Block blocks[] = {
 	BLOCK("sb-mail",    1800, 17),
 	BLOCK("sb-music",   0,    18),

--- a/main.c
+++ b/main.c
@@ -11,14 +11,7 @@
 
 #define LEN(arr) (sizeof(arr) / sizeof(arr[0]))
 #define MAX(a, b) (a > b ? a : b)
-#define BLOCK(cmd, interval, signal) \
-    { "echo \"$(" cmd ")\"", interval, signal }
 
-typedef const struct {
-    const char *command;
-    const unsigned int interval;
-    const unsigned int signal;
-} Block;
 #include "config.h"
 
 #ifdef CLICKABLE_BLOCKS


### PR DESCRIPTION
make again if the config.h change too
```diff
- $(BIN): main.o
+ $(BIN): main.o config.h
```
move the `BLOCK` macro and `Block` struct to `config.h`, which helps to show the correct diagnostic by `clangd` and `ccls` 