### PR TITLE
use a different pipe for every child process

### DIFF
--- a/main.c
+++ b/main.c
@@ -130,7 +130,10 @@ void updateBlock(int i) {
 
     close(pipes[i][0]);
 
-    if (bytesRead == 0) return;
+    if (bytesRead == 0) {
+        execLock &= ~(1 << i);
+        return;
+    }
 
     // Trim UTF-8 string to desired length
     int count = 0, j = 0;

--- a/main.c
+++ b/main.c
@@ -129,12 +129,10 @@ void updateBlock(int i) {
     char *output = outputs[i];
     char buffer[LEN(outputs[0]) - CLICKABLE_BLOCKS];
 
-    if (pipes[i][0] < 0)
-        return;
+    if (execLock & 1 << i) return;
 
     int bytesRead = read_pipe(pipes[i][0], buffer, LEN(buffer));
     close(pipes[i][0]);
-    pipes[i][0] = -1;
 
     // Trim UTF-8 string to desired length
     int count = 0, j = 0;

--- a/main.c
+++ b/main.c
@@ -129,7 +129,7 @@ void updateBlock(int i) {
     char *output = outputs[i];
     char buffer[LEN(outputs[0]) - CLICKABLE_BLOCKS];
 
-    if (execLock & 1 << i) return;
+    if (!(execLock & 1 << i)) return;
 
     int bytesRead = read_pipe(pipes[i][0], buffer, LEN(buffer));
     close(pipes[i][0]);

--- a/main.c
+++ b/main.c
@@ -130,11 +130,6 @@ void updateBlock(int i) {
 
     close(pipes[i][0]);
 
-    if (bytesRead == 0) {
-        execLock &= ~(1 << i);
-        return;
-    }
-
     // Trim UTF-8 string to desired length
     int count = 0, j = 0;
     while (j < bytesRead && count < CMDLENGTH) {

--- a/main.c
+++ b/main.c
@@ -72,7 +72,7 @@ void execBlock(int i, const char *button) {
     // Lock execution of block until current instance finishes execution
     execLock |= 1 << i;
 
-    // Append the block's pipe to `epollFD`
+    // Open a new pipe for every new block command
     pipe(pipes[i]);
 
     if (fork() == 0) {

--- a/main.c
+++ b/main.c
@@ -201,7 +201,8 @@ void signalHandler() {
 
     for (int j = 0; j < LEN(blocks); j++) {
         if (blocks[j].signal == signal - SIGRTMIN) {
-            char button[] = {'0' + info.ssi_int & 0xff, 0};
+            char button[4];  // value can't be more than 255;
+            sprintf(button, "%d", info.ssi_int & 0xff);
             execBlock(j, button);
             break;
         }

--- a/main.c
+++ b/main.c
@@ -122,15 +122,19 @@ read_pipe(int fd, char *buffer, size_t size)
     while ((r = read(fd, buffer + total, size - total)) > 0)
         total += r;
 
-    return total;
+    return r ?: total;
 }
 
 void updateBlock(int i) {
     char *output = outputs[i];
     char buffer[LEN(outputs[0]) - CLICKABLE_BLOCKS];
-    int bytesRead = read_pipe(pipes[i][0], buffer, LEN(buffer));
 
+    if (pipes[i][0] < 0)
+        return;
+
+    int bytesRead = read_pipe(pipes[i][0], buffer, LEN(buffer));
     close(pipes[i][0]);
+    pipes[i][0] = -1;
 
     // Trim UTF-8 string to desired length
     int count = 0, j = 0;


### PR DESCRIPTION
fixes #24 

with this patch, I noticed that some blocks are updated more often than they should (apparently it only happens when they exit without writing anything, and it doesn't apply to every block, I couldn't figure out why), which is why I added the early return in `updateBlock()`. I could use some help to properly fix that