### PR TITLE
Improve grammar, consistency, and brevity of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Both are executed at the same rate, which is wasteful. Ideally, the mail counter
 ## Why `dwmblocks-async`?
 The magic of `dwmblocks-async` is in the `async` part. Since vanilla `dwmblocks` executes the commands of each block sequentially, it leads to annoying freezes. In cases where one block takes several seconds to execute, like in the mail and date blocks example from above, the delay is clearly visible. Fire up a new instance of `dwmblocks` and you'll see!
 
-With `async`, the computer executes each block asynchronously (simultaneously).
+With `dwmblocks-async`, the computer executes each block asynchronously (simultaneously).
 
 ## Installation
 Clone this repository, modify `config.h` appropriately, then compile the program:
@@ -57,7 +57,7 @@ sudo make install
 To set `dwmblocks-async` as your statusbar, you need to run it as a background process on startup. One way is to add the following to `~/.xinitrc`:
 
 ```sh
-# Binary of `dwmblocks-async` is named `dwmblocks`
+# The binary of `dwmblocks-async` is named `dwmblocks`
 dwmblocks &
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # dwmblocks-async
-A [`dwm`](https://dwm.suckless.org) statusbar that has a modular, async design, ensuring it will always remain responsive, no matter how many blocks you have configured. Imagine `i3blocks`, but for `dwm`.
+A [`dwm`](https://dwm.suckless.org) status bar that has a modular, async design, so it is always responsive. Imagine `i3blocks`, but for `dwm`.
 
 ![A lean config of dwmblocks-async.](preview.png)
 
@@ -7,16 +7,16 @@ A [`dwm`](https://dwm.suckless.org) statusbar that has a modular, async design, 
 - [Modular](#modifying-the-blocks)
 - Lightweight
 - [Suckless](https://suckless.org/philosophy)
-- Blocks
+- Blocks:
     - [Clickable](#clickable-blocks)
-    - Async loaded
-    - [Can be externally triggered to update](#signalling-changes)
+    - Loaded asynchronously
+    - [Updates can be externally triggered](#signalling-changes)
 - Compatible with `i3blocks` scripts
 
-> Additionally, this build of `dwmblocks` is more optimized and fixes the flickering of the statusbar when scrolling.
+> Additionally, this build of `dwmblocks` is more optimized and fixes the flickering of the status bar when scrolling.
 
 ## Why `dwmblocks`?
-In `dwm`, you have to set the statusbar through an infinite loop, like so:
+In `dwm`, you have to set the status bar through an infinite loop, like so:
 
 ```sh
 while :; do
@@ -25,7 +25,7 @@ while :; do
 done
 ```
 
-This is inefficient when running multiple commands that need to be updated at different frequencies. For example, to display an unread mail count and a clock in the statusbar:
+This is inefficient when running multiple commands that need to be updated at different frequencies. For example, to display an unread mail count and a clock in the status bar:
 
 ```sh
 while :; do
@@ -36,7 +36,7 @@ done
 
 Both are executed at the same rate, which is wasteful. Ideally, the mail counter would be updated every thirty minutes, since there's a limit to the number of requests I can make using Gmail's APIs (as a free user).  
 
-`dwmblocks` devides the statusbar into multiple blocks, each of which can be updated at its own interval. The commands in a given block are only executed once within that interval, effectively addressing the previous issue.
+`dwmblocks` allows you to divide the status bar into multiple blocks, each of which can be updated at its own interval. This effectively addresses the previous issue, because the commands in a block are only executed once within that time frame.
 
 ## Why `dwmblocks-async`?
 The magic of `dwmblocks-async` is in the `async` part. Since vanilla `dwmblocks` executes the commands of each block sequentially, it leads to annoying freezes. In cases where one block takes several seconds to execute, like in the mail and date blocks example from above, the delay is clearly visible. Fire up a new instance of `dwmblocks` and you'll see!
@@ -54,7 +54,7 @@ sudo make install
 ```
 
 ## Usage
-To set `dwmblocks-async` as your statusbar, you need to run it as a background process on startup. One way is to add the following to `~/.xinitrc`:
+To set `dwmblocks-async` as your status bar, you need to run it as a background process on startup. One way is to add the following to `~/.xinitrc`:
 
 ```sh
 # The binary of `dwmblocks-async` is named `dwmblocks`
@@ -62,7 +62,7 @@ dwmblocks &
 ```
 
 ### Modifying the blocks
-You can define your statusbar blocks in `config.h`:
+You can define your status bar blocks in `config.h`:
 
 ```c
 const Block blocks[] = {
@@ -87,10 +87,10 @@ Additional parameters can be modified:
 // Maximum possible length of output from block, expressed in number of characters.
 #define CMDLENGTH 50
 
-// The statusbar's delimiter that appears in between each block.
+// The status bar's delimiter that appears in between each block.
 #define DELIMITER " "
 
-// Adds a leading delimiter to the statusbar, useful for powerline.
+// Adds a leading delimiter to the status bar, useful for powerline.
 #define LEADING_DELIMITER
 
 // Enable clickability for blocks. See the "Clickable blocks" section below.
@@ -98,7 +98,7 @@ Additional parameters can be modified:
 ```
 
 ### Signalling changes
-Most statusbars constantly rerun all scripts every few seconds. This is an option here, but a superior choice is to give your block a signal through which you can indicate it to update on relevant event, rather than have it rerun idly.
+Most status bars constantly rerun all scripts every few seconds. This is an option here, but a superior choice is to give your block a signal through which you can indicate it to update on relevant event, rather than have it rerun idly.
 
 For example, the volume block has the update signal `5` by default. I run `kill -39 $(pidof dwmblocks)` alongside my volume shortcuts in `dwm` to only update it when relevant. Just add `34` to your signal number! You could also run `pkill -RTMIN+5 dwmblocks`, but it's slower.
 
@@ -107,7 +107,7 @@ To refresh all the blocks, run `kill -10 $(pidof dwmblocks)` or `pkill -SIGUSR1 
 > All blocks must have different signal numbers!
 
 ### Clickable blocks
-Like `i3blocks`, this build allows you to build in additional actions into your scripts in response to click events. You can check out [my statusbar scripts](https://github.com/UtkarshVerma/dotfiles/tree/main/.local/bin/statusbar) as references for using the `$BLOCK_BUTTON` variable.
+Like `i3blocks`, this build allows you to build in additional actions into your scripts in response to click events. You can check out [my status bar scripts](https://github.com/UtkarshVerma/dotfiles/tree/main/.local/bin/statusbar) as references for using the `$BLOCK_BUTTON` variable.
 
 To use this feature, define the `CLICKABLE_BLOCKS` feature macro in your `config.h`:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ An async, modular statusbar for `dwm`. You may think of it as `i3blocks`, but fo
 
 ## Why `dwmblocks`?
 In `dwm`, you have to set the statusbar through an infinite loop like this:
-
 ```sh
 while :; do
     xsetroot -name "$(date)"
@@ -24,32 +23,27 @@ while :; do
 done
 ```
 
-It may not look bad, but it's certainly inefficient when running multiple commands that need to be updated at different frequencies:
-
+This is inefficient when running multiple commands that need to be updated at different frequencies. For example, displaying an unread mail count and a clock in the statusbar:
 ```sh
-# Displaying an unread mail count in the status bar
 while :; do
     xsetroot -name "$(mailCount) $(date)"
     sleep 60
 done
 ```
 
-For example, displaying an unread mail count and a clock in my statusbar will cause both to be updated at the same rate. This is wasteful. Ideally, the mail counter would be updated every thirty minutes, since there's a limit to the number of requests I can make using Gmail's APIs, being a free user.  
+Both are executed at the same rate, which is wasteful. Ideally, the mail counter would be updated every thirty minutes, since there's a limit to the number of requests I can make using Gmail's APIs (as a free user).  
 
 `dwmblocks` allows you to break up the statusbar into multiple blocks, each having their own update interval. The commands in a particular block are only executed once in that interval, solving our previous problem.
 
 > Additionally, you can externally trigger any specific block.
 
-
 ## Why `dwmblocks-async`?
 The magic of `dwmblocks-async` is in the `async` part. Since vanilla `dwmblocks` executes the commands of each block sequentially, it leads to annoying freezes. In cases where one block takes several seconds to execute, like in the mail and date blocks example from above, the delay is clearly visible. Fire up a new instance of `dwmblocks` and you'll see!
 
-With `async`, we tell the computer to execute each block asynchronously (simultaneously).
-
+With `async`, the computer executes each block asynchronously (simultaneously).
 
 ## Installation
 Clone this repository, modify `config.h` appropriately, then compile the program:
-
 ```sh
 git clone https://github.com/UtkarshVerma/dwmblocks-async.git
 cd dwmblocks-async
@@ -57,9 +51,8 @@ vi config.h
 sudo make install
 ```
 
-
 ## Usage
-To set `dwmblocks-async` as your statusbar, you need to run it as a background process on startup. One way is by adding the following to `~/.xinitrc`:
+To set `dwmblocks-async` as your statusbar, you need to run it as a background process on startup. One way is to add the following to `~/.xinitrc`:
 
 ```sh
 # Binary of `dwmblocks-async` is named `dwmblocks`
@@ -67,16 +60,7 @@ dwmblocks &
 ```
 
 ### Modifying the blocks
-You can define your statusbar blocks in `config.h`. Each block has the following properties:
-
-Property|Value
--|-
-Command | The command you wish to execute in your block
-Update interval | Time in seconds, after which you want the block to update. If `0`, the block will never be updated.
-Update signal | Signal to be used for triggering the block. Must be a positive integer. If `0`, a signal won't be set up for the block and it will be unclickable.
-
-The syntax for defining a block is:
-
+You can define your statusbar blocks in `config.h`: 
 ```c
 const Block blocks[] = {
     ...
@@ -85,6 +69,14 @@ const Block blocks[] = {
     ...
 }
 ```
+
+Each block has the following properties:
+
+Property|Description
+-|-
+Command | The command you wish to execute in your block
+Update interval | Time in seconds, after which you want the block to update. If `0`, the block will never be updated.
+Update signal | Signal to be used for triggering the block. Must be a positive integer. If `0`, a signal won't be set up for the block and it will be unclickable.
 
 Additional parameters can be modified:
 
@@ -98,8 +90,7 @@ Additional parameters can be modified:
 // Adds a leading delimiter to the statusbar, useful for powerline.
 #define LEADING_DELIMITER
 
-// Enable clickability for blocks. Needs `dwm` to be patched appropriately.
-// See the "Clickable blocks" section below.
+// Enable clickability for blocks. See the "Clickable blocks" section below.
 #define CLICKABLE_BLOCKS
 ```
 
@@ -110,12 +101,12 @@ For example, the volume block has the update signal 5 by default:
 
 Command|Effect
 -|-
-`pkill -RTMIN+5 dwmblocks`|Update block|
-`kill -39 $(pidof dwmblocks)`|Same, but faster. Just add 34 to your typical signal number|
-`pkill -SIGUSR1 dwmblocks`|Refresh all blocks|
-`kill -10 $(pidof dwmblocks)`|Same, but faster|
+`pkill -RTMIN+5 dwmblocks`|Update block
+`kill -39 $(pidof dwmblocks)`|Update, but faster. Add 34 to your signal number!
+`pkill -SIGUSR1 dwmblocks`|Refresh all blocks
+`kill -10 $(pidof dwmblocks)`|Refresh, but faster
 
-My volume block *never* updates on its own. Instead, I use this command alongside my volume shortcuts in `dwm` to only update it when relevant.
+My volume block *never* updates on its own. Instead, I use the 2nd command alongside my volume shortcuts in `dwm` to only update it when relevant.
 
 > All blocks must have different signal numbers!
 

--- a/README.md
+++ b/README.md
@@ -97,16 +97,9 @@ Additional parameters can be modified:
 ### Signalling changes
 Most statusbars constantly rerun all scripts every few seconds. This is an option here, but a superior choice is to give your block a signal through which you can indicate it to update on relevant event, rather than have it rerun idly.
 
-For example, the volume block has the update signal 5 by default:
+For example, the volume block has the update signal `5` by default. I run `kill -39 $(pidof dwmblocks)` alongside my volume shortcuts in `dwm` to only update it when relevant. Just add `34` to your signal number! You could also run `pkill -RTMIN+5 dwmblocks`, but it's slower.
 
-Command|Effect
--|-
-`pkill -RTMIN+5 dwmblocks`|Update block
-`kill -39 $(pidof dwmblocks)`|Update, but faster. Add 34 to your signal number!
-`pkill -SIGUSR1 dwmblocks`|Refresh all blocks
-`kill -10 $(pidof dwmblocks)`|Refresh, but faster
-
-My volume block *never* updates on its own. Instead, I use the 2nd command alongside my volume shortcuts in `dwm` to only update it when relevant.
+To refresh all the blocks, run `kill -10 $(pidof dwmblocks)` or `pkill -SIGUSR1 dwmblocks`.
 
 > All blocks must have different signal numbers!
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,23 @@
 # dwmblocks-async
-An async, modular statusbar for `dwm`. You may think of it as `i3blocks`, but for `dwm`.
+A [`dwm`](https://dwm.suckless.org) statusbar that has a modular, async design, ensuring it will always remain responsive, no matter how many blocks you have configured. Imagine `i3blocks`, but for `dwm`.
 
 ![A lean config of dwmblocks-async.](preview.png)
 
 ## Features
-- Modular
+- [Modular](#modifying-the-blocks)
 - Lightweight
-- Suckless
-- Blocks are clickable
-- Blocks are loaded asynchronously
-- Each block can be externally triggered to update itself
+- [Suckless](https://suckless.org/philosophy)
+- Blocks
+    - [Clickable](#clickable-blocks)
+    - Async loaded
+    - [Can be externally triggered to update](#signalling-changes)
 - Compatible with `i3blocks` scripts
 
 > Additionally, this build of `dwmblocks` is more optimized and fixes the flickering of the statusbar when scrolling.
 
 ## Why `dwmblocks`?
-In `dwm`, you have to set the statusbar through an infinite loop like this:
+In `dwm`, you have to set the statusbar through an infinite loop, like so:
+
 ```sh
 while :; do
     xsetroot -name "$(date)"
@@ -23,7 +25,8 @@ while :; do
 done
 ```
 
-This is inefficient when running multiple commands that need to be updated at different frequencies. For example, displaying an unread mail count and a clock in the statusbar:
+This is inefficient when running multiple commands that need to be updated at different frequencies. For example, to display an unread mail count and a clock in the statusbar:
+
 ```sh
 while :; do
     xsetroot -name "$(mailCount) $(date)"
@@ -33,7 +36,7 @@ done
 
 Both are executed at the same rate, which is wasteful. Ideally, the mail counter would be updated every thirty minutes, since there's a limit to the number of requests I can make using Gmail's APIs (as a free user).  
 
-`dwmblocks` allows you to break up the statusbar into multiple blocks, each having their own update interval. The commands in a particular block are only executed once in that interval, solving our previous problem.
+`dwmblocks` devides the statusbar into multiple blocks, each of which can be updated at its own interval. The commands in a given block are only executed once within that interval, effectively addressing the previous issue.
 
 ## Why `dwmblocks-async`?
 The magic of `dwmblocks-async` is in the `async` part. Since vanilla `dwmblocks` executes the commands of each block sequentially, it leads to annoying freezes. In cases where one block takes several seconds to execute, like in the mail and date blocks example from above, the delay is clearly visible. Fire up a new instance of `dwmblocks` and you'll see!
@@ -42,6 +45,7 @@ With `async`, the computer executes each block asynchronously (simultaneously).
 
 ## Installation
 Clone this repository, modify `config.h` appropriately, then compile the program:
+
 ```sh
 git clone https://github.com/UtkarshVerma/dwmblocks-async.git
 cd dwmblocks-async
@@ -58,7 +62,8 @@ dwmblocks &
 ```
 
 ### Modifying the blocks
-You can define your statusbar blocks in `config.h`: 
+You can define your statusbar blocks in `config.h`:
+
 ```c
 const Block blocks[] = {
     ...
@@ -72,7 +77,7 @@ Each block has the following properties:
 
 Property|Description
 -|-
-Command | The command you wish to execute in your block
+Command | The command you wish to execute in your block.
 Update interval | Time in seconds, after which you want the block to update. If `0`, the block will never be updated.
 Update signal | Signal to be used for triggering the block. Must be a positive integer. If `0`, a signal won't be set up for the block and it will be unclickable.
 
@@ -111,7 +116,6 @@ To use this feature, define the `CLICKABLE_BLOCKS` feature macro in your `config
 ```
 
 Apart from that, you need `dwm` to be patched with [statuscmd](https://dwm.suckless.org/patches/statuscmd/).
-
 
 ## Credits
 This work would not have been possible without [Luke's build of dwmblocks](https://github.com/LukeSmithxyz/dwmblocks) and [Daniel Bylinka's statuscmd patch](https://dwm.suckless.org/patches/statuscmd/).

--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ Both are executed at the same rate, which is wasteful. Ideally, the mail counter
 
 `dwmblocks` allows you to break up the statusbar into multiple blocks, each having their own update interval. The commands in a particular block are only executed once in that interval, solving our previous problem.
 
-> Additionally, you can externally trigger any specific block.
-
 ## Why `dwmblocks-async`?
 The magic of `dwmblocks-async` is in the `async` part. Since vanilla `dwmblocks` executes the commands of each block sequentially, it leads to annoying freezes. In cases where one block takes several seconds to execute, like in the mail and date blocks example from above, the delay is clearly visible. Fire up a new instance of `dwmblocks` and you'll see!
 


### PR DESCRIPTION
I noticed the README file contained some grammatical errors and strange wording:
1. To have `dwmblocks-async` set your statusbar -> To set `dwmblocks-async` as your statusbar
2. a signal that you can signal to it -> a signal through which you can indicate it to

Some paragraphs have been expanded upon, others stripped down.