### PR TITLE
Include xcb-xrand library in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SRC_DIR := src
 INC_DIR := include
 
 VERBOSE := 0
-LIBS := xcb-atom
+LIBS := xcb-atom xcb-randr
 
 PREFIX := /usr/local
 CFLAGS := -Ofast -I. -I$(INC_DIR) -std=c99

--- a/config.h
+++ b/config.h
@@ -18,15 +18,13 @@
 
 // Define blocks for the status feed as X(cmd, interval, signal).
 #define BLOCKS(X)         \
-    X("sb-mail", 600, 1)  \
-    X("sb-music", 0, 2)   \
-    X("sb-disk", 1800, 3) \
-    X("sb-memory", 10, 4) \
-    X("sb-loadavg", 5, 5) \
-    X("sb-mic", 0, 6)     \
-    X("sb-record", 0, 7)  \
-    X("sb-volume", 0, 8)  \
-    X("sb-battery", 5, 9) \
-    X("sb-date", 1, 10)
+
+    X("dwmb-curr_song",	 0  , 3)  \
+    X("dwmb-volume",	 0  , 1)  \
+    X("dwmb-memory",	 10 , 2)  \
+    X("dwmb-cpu_temp",	 10 , 0)  \
+    X("dwmb-date",	 180, 0)  \
+    X("dwmb-clock",	 1  , 0)  \
+    X("dwmb-battery",	 30 , 0)  
 
 #endif  // CONFIG_H

--- a/config.h
+++ b/config.h
@@ -5,10 +5,10 @@
 #define DELIMITER "  "
 
 // Maximum number of Unicode characters that a block can output.
-#define MAX_BLOCK_OUTPUT_LENGTH 45
+#define MAX_BLOCK_OUTPUT_LENGTH 65
 
 // Control whether blocks are clickable.
-#define CLICKABLE_BLOCKS 1
+#define CLICKABLE_BLOCKS 0
 
 // Control whether a leading delimiter should be prepended to the status.
 #define LEADING_DELIMITER 0

--- a/config.h
+++ b/config.h
@@ -18,7 +18,6 @@
 
 // Define blocks for the status feed as X(cmd, interval, signal).
 #define BLOCKS(X)         \
-
     X("dwmb-curr_song",	 0  , 3)  \
     X("dwmb-volume",	 0  , 1)  \
     X("dwmb-memory",	 10 , 2)  \
@@ -26,5 +25,4 @@
     X("dwmb-date",	 180, 0)  \
     X("dwmb-clock",	 1  , 0)  \
     X("dwmb-battery",	 30 , 0)  
-
 #endif  // CONFIG_H


### PR DESCRIPTION
**OS**: Arch Linux
Although I installed all the packages that included `xcb`  in the title, I could not compile the dwmblocks-async with command: `sudo make install` with the error:
```
make: pkg-config: No such file or directory
make: pkg-config: No such file or directory
LD       build/dwmblocks
/usr/bin/ld: build/x11.o: in function `x11_connection_open':
x11.c:(.text+0x6): undefined reference to `xcb_connect'
/usr/bin/ld: x11.c:(.text+0x11): undefined reference to `xcb_connection_has_error'
/usr/bin/ld: build/x11.o: in function `x11_set_root_name':
x11.c:(.text+0x6b): undefined reference to `xcb_get_setup'
/usr/bin/ld: x11.c:(.text+0x73): undefined reference to `xcb_setup_roots_iterator'
/usr/bin/ld: x11.c:(.text+0x9f): undefined reference to `xcb_change_property'
/usr/bin/ld: x11.c:(.text+0xa9): undefined reference to `xcb_request_check'
/usr/bin/ld: x11.c:(.text+0xe4): undefined reference to `xcb_flush'
/usr/bin/ld: build/x11.o: in function `x11_connection_close':
x11.c:(.text+0x51): undefined reference to `xcb_disconnect'
collect2: error: ld returned 1 exit status
make: *** [Makefile:38: build/dwmblocks] Error 1
```
But after including `xcb-randr` at the end of the line 9  in Makefile file, it was compiled just fine 
So I made this pull request to help resolve anyone who having the same issue

Output of the installed packages related to xcb:
`pacman -Q | grep xcb` : 
```
libxcb 1.16-1
xcb-imdkit 1.0.5-1
xcb-proto 1.16.0-1
xcb-util 0.4.1-1
xcb-util-cursor 0.1.5-1
xcb-util-errors 1.0.1-1
xcb-util-image 0.4.1-2
xcb-util-keysyms 0.4.1-4
xcb-util-renderutil 0.3.10-1
xcb-util-wm 0.4.2-1
xcb-util-xrm 1.3-2
```
P.S. I apologize I broke some guidelines. It's my first ever public pull request